### PR TITLE
[🪽 FEAT] 게임 종료 후 자동으로 대기 상태로 돌아가도록 구현

### DIFF
--- a/handtris/src/app/play/tetris/page.tsx
+++ b/handtris/src/app/play/tetris/page.tsx
@@ -98,6 +98,16 @@ const Home: React.FC = () => {
       subscribeToState();
     }
   }, [isOwner]);
+  // Add useEffect to handle the timeout for hiding gameResult
+  useEffect(() => {
+    if (gameResult) {
+      const timeoutId = setTimeout(() => {
+        setGameResult(null);
+      }, 3000); // 3 seconds
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [gameResult]);
 
   const subscribeToState = async () => {
     if (!wsWaitingManagerRef.current) {

--- a/handtris/src/app/play/tetris/page.tsx
+++ b/handtris/src/app/play/tetris/page.tsx
@@ -103,6 +103,8 @@ const Home: React.FC = () => {
     if (gameResult) {
       const timeoutId = setTimeout(() => {
         setGameResult(null);
+        setIsStart(false);
+        setIsAllReady(false);
       }, 3000); // 3 seconds
 
       return () => clearTimeout(timeoutId);


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- 기능 추가
## 반영 사항
- 게임 종료 후 모달 창이 3초 후에 사라지도록 useEffect() 구현
- 모달 창이 사라진 후에 새로운 게임을 시작할 수 있도록 `isStart`, `isAllReady` 상태 초기화