### PR TITLE
[🪽 FEAT] 다음에 나올 블럭이 보이도록 구현

### DIFF
--- a/handtris/src/app/play/tetris/page.tsx
+++ b/handtris/src/app/play/tetris/page.tsx
@@ -24,6 +24,7 @@ import { motion } from "framer-motion";
 import { containerVariants, itemVariants } from "@/util/animation";
 
 const TETRIS_CANVAS = `flex items-center justify-between w-full border-2 border-t-0`;
+
 const Home: React.FC = () => {
   const [isConnected, setIsConnected] = useState(false);
   const [isOwner, setIsOwner] = useState<boolean | null>(null);
@@ -59,12 +60,46 @@ const Home: React.FC = () => {
   const lastGestureRef = useRef<string | null>(null);
   const [showCountdown, setShowCountdown] = useState(true);
 
+  const drawNextBlock = (nextBlock: Piece) => {
+    const canvas = nextBlockRef.current;
+
+    if (canvas && nextBlock) {
+      const context = canvas.getContext('2d');
+      if (context) {
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        nextBlock.activeTetromino.forEach((row, y) => {
+          row.forEach((value, x) => {
+            if (value && tetrisGameRef.current) {
+              if(nextBlock.color === 'orange' ) {
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.9, y+1, nextBlock.color, false);
+              } else if(nextBlock.color === 'yellow') { 
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.7, y+1.65, nextBlock.color, false);
+              } else if(nextBlock.color === 'red') { 
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.7, y+1.7, nextBlock.color, false);
+              } else if(nextBlock.color === 'cyan') { 
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.1, y+1, nextBlock.color, false);
+              } else if(nextBlock.color === 'green') { 
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.7, y+1.6, nextBlock.color, false);
+              } else if(nextBlock.color === 'purple') { 
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.25, y+1, nextBlock.color, false);
+              }
+               else { // blue 처리
+                tetrisGameRef.current.drawSquareCanvas(context, x+1.2, y+0.5, nextBlock.color, false);
+              }
+            }
+          });
+        });
+      }
+    }
+  };
+
   useEffect(() => {
     const roomCode = getRoomCode();
     if (tetrisGameRef.current) {
       tetrisGameRef.current.roomCode = roomCode;
     }
   });
+
   useEffect(() => {
     const roomCode = getRoomCode();
     const token = getAccessToken();
@@ -114,6 +149,7 @@ const Home: React.FC = () => {
       subscribeToState();
     }
   }, [isOwner]);
+
   // 게임 종료 시 결과 표시 모달 지우고, 게임 시작 관련 상태 초기화
   useEffect(() => {
     if (gameResult) {
@@ -234,6 +270,7 @@ const Home: React.FC = () => {
         }, 1000);
       });
     };
+
     if (canvasTetrisRef.current && canvasTetris2Ref.current) {
       const ctx = canvasTetrisRef.current.getContext("2d")!;
       const ctx2 = canvasTetris2Ref.current.getContext("2d")!;
@@ -525,6 +562,7 @@ const Home: React.FC = () => {
       handleReadyClick();
     }
   };
+
   const gameResultStyle =
     "block absolute top-1/3 left-1/2 transform -translate-x-1/2 -translate-y-1/2 p-20 bg-white bg-opacity-20 text-white text-6xl rounded-3xl text-center backdrop-blur-xl border-xl border-white border-opacity-20";
   const resultText = gameResult;
@@ -544,6 +582,7 @@ const Home: React.FC = () => {
         });
     }
   }, []);
+
   return (
     <motion.div variants={containerVariants} initial="hidden" animate="visible">
       <div className="flex items-center justify-around">
@@ -565,7 +604,7 @@ const Home: React.FC = () => {
                 width="400"
                 height="800"
               />
-              <div ref={borderRef} id="tetris-border" />
+              {/* <div ref={borderRef} id="tetris-border" /> */}
             </div>
             <NameLabel name={"USER1"} />
           </div>

--- a/handtris/src/app/play/tetris/page.tsx
+++ b/handtris/src/app/play/tetris/page.tsx
@@ -42,11 +42,13 @@ const Home: React.FC = () => {
   const [linesCleared, setLinesCleared] = useState(0);
   const [gauge, setGauge] = useState(0);
   const [isGaugeFull, setIsGaugeFull] = useState(false);
+  const [nextBlock, setNextBlock] = useState<Piece | null>(null);
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvasTetrisRef = useRef<HTMLCanvasElement>(null);
   const canvasTetris2Ref = useRef<HTMLCanvasElement>(null);
+  const nextBlockRef = useRef<HTMLCanvasElement>(null);
   const gestureRef = useRef<HTMLDivElement>(null);
   const borderRef = useRef<HTMLDivElement>(null);
   const wsManagerRef = useRef<WebSocketManager | null>(null);
@@ -262,6 +264,7 @@ const Home: React.FC = () => {
         );
         setLinesCleared(tetrisGameRef.current.linesCleared);
         tetrisGameRef.current.roomCode = getRoomCode();
+        setNextBlock(tetrisGameRef.current.getNextBlock());
       } catch (error) {
         console.error("Failed to connect to WebSocket for game", error);
       }
@@ -293,6 +296,8 @@ const Home: React.FC = () => {
             setGauge(0);
           }, 2000);
         }
+        setNextBlock(tetrisGameRef.current.getNextBlock());
+        drawNextBlock(tetrisGameRef.current.getNextBlock());
       }
     }, 1000);
     return () => clearInterval(interval);
@@ -568,6 +573,12 @@ const Home: React.FC = () => {
             <div className="press bg-white text-center text-2xl text-black">
               NEXT
             </div>
+            <canvas
+              ref={nextBlockRef}
+              width="250"
+              height="250"
+              className="w-full h-full"
+            />
           </div>
         </div>
         <div className="flex h-[802px]">

--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -67,6 +67,14 @@ export class TetrisGame {
   isGameStart: boolean;
   isRowFull: boolean;
   isAttack: boolean;
+  nextBlock: Piece;
+  drawSquareCanvas: (
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    color: string,
+    isGhost: boolean,
+  ) => void;
 
   constructor(
     ctx: CanvasRenderingContext2D,
@@ -82,6 +90,7 @@ export class TetrisGame {
     this.ctx = ctx;
     this.ctx2 = ctx2;
     this.p = this.randomPiece();
+    this.nextBlock = this.randomPiece(); // 다음 블럭 초기화
     this.dropStart = Date.now();
     this.gameOver = false;
     this.wsManager = wsManager;
@@ -95,6 +104,7 @@ export class TetrisGame {
     this.isAttack = false;
 
     this.drawBoard();
+    this.drawSquareCanvas = this.drawSquare;
     this.drop();
     this.roomCode = "";
   }
@@ -195,6 +205,10 @@ export class TetrisGame {
     return new Piece(piece.shape, piece.color, this);
   }
 
+  getNextBlock(): Piece {
+    return this.nextBlock;
+  }
+
   drop() {
     const now = Date.now();
     const delta = now - this.dropStart;
@@ -260,6 +274,7 @@ export class TetrisGame {
     this.p.y = originalPosition.y;
     return ghostPosition;
   }
+
   addBlockRow = () => {
     const newRow = new Array(this.COL).fill("grey");
     const randomIndex = Math.floor(Math.random() * this.COL);
@@ -370,7 +385,8 @@ class Piece {
       this.draw();
     } else {
       this.lock();
-      this.game.p = this.game.randomPiece();
+      this.game.p = this.game.nextBlock;
+      this.game.nextBlock = this.game.randomPiece();
       this.game.p.drawGhost();
     }
   }


### PR DESCRIPTION
> Closes #103 

## PR 타입 (하나 이상의 PR 타입 선택)
- 기능 추가
## 반영 사항
- `nextBlock`을 현재 블럭인 `game.p`에 할당하고, 동시에 `nextBlock`에는 랜덤 `Piece`를 할당하는 로직