### PR TITLE
[🪽 FEAT] Back to Lobby 시 exit 요청 연결

### DIFF
--- a/handtris/src/components/WaitingModal.tsx
+++ b/handtris/src/components/WaitingModal.tsx
@@ -49,7 +49,10 @@ const WaitingModal = ({
   const isButtonDisabled = players.length < 2;
 
   const handleBackToLobby = () => {
+    sessionStorage.removeItem("roomCode");
+    sessionStorage.removeItem("roomName");
     exitRoom(sessionStorage.getItem("roomCode") as string);
+
     router.push("/lobby");
   };
 

--- a/handtris/src/components/WaitingModal.tsx
+++ b/handtris/src/components/WaitingModal.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ArrowLeft } from "lucide-react";
 import { getRoomName } from "@/util/getRoomCode";
 import { useRouter } from "next/navigation";
+import { exitRoom } from "@/services/gameService";
 
 export interface Player {
   nickname: string;
@@ -48,6 +49,7 @@ const WaitingModal = ({
   const isButtonDisabled = players.length < 2;
 
   const handleBackToLobby = () => {
+    exitRoom(sessionStorage.getItem("roomCode") as string);
     router.push("/lobby");
   };
 


### PR DESCRIPTION
기존  router.push('/lobby') 로직에서 exitRoom API연결