### PR TITLE
[🪽 FEAT] Waiting Modal에서 BackToLobby 버튼 클릭시 소켓 연결 disconnect

### DIFF
--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -754,6 +754,7 @@ const Home: React.FC = () => {
         {showWaitingModal && (
           <WaitingModal
             isOpen={showWaitingModal}
+            wsManager={wsManagerRef.current!}
             isLoading={isLoading}
             onClose={() => setShowWaitingModal(false)}
             onReady={handleReadyStartClick}

--- a/handtris/src/components/WaitingModal.tsx
+++ b/handtris/src/components/WaitingModal.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from "lucide-react";
 import { getRoomName } from "@/util/getRoomCode";
 import { useRouter } from "next/navigation";
 import { exitRoom } from "@/services/gameService";
+import { WebSocketManager } from "./WebSocketManager";
 
 export interface Player {
   nickname: string;
@@ -22,6 +23,7 @@ interface WaitingModalProps {
   onReady: () => void;
   isOwner: boolean | null;
   isAllReady: boolean;
+  wsManager: WebSocketManager;
   players: Player[];
 }
 
@@ -33,6 +35,7 @@ const WaitingModal = ({
   isOwner,
   isAllReady,
   players = [],
+  wsManager,
 }: WaitingModalProps) => {
   const router = useRouter();
   if (!isOpen) return null;
@@ -49,7 +52,15 @@ const WaitingModal = ({
   const isButtonDisabled = players.length < 2;
 
   const handleBackToLobby = () => {
-    exitRoom(sessionStorage.getItem("roomCode") as string);
+    const roomCode = sessionStorage.getItem("roomCode");
+    if (roomCode && wsManager && wsManager.connected) {
+      wsManager.sendMessageOnDisconnecting(
+        {},
+        `/app/${roomCode}/disconnect`,
+        false, // isStart는 대기실에서 false입니다
+      );
+    }
+    exitRoom(roomCode as string);
     sessionStorage.removeItem("roomCode");
     sessionStorage.removeItem("roomName");
 


### PR DESCRIPTION
이제 유저가 BackToLobby버튼 클릭시 
Waiting Modal에서 상대방이 제거되고 다시 대기 로딩으로 넘어감 