### PR TITLE
게임 재시작 시 발생 버그 수정(WS 중복 연결 및 이전 게임 결과 블럭 렌더링)

### DIFF
--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -83,7 +83,6 @@ const Home: React.FC = () => {
 
   const drawNextBlock = (nextBlock: Piece) => {
     const canvas = nextBlockRef.current;
-
     if (canvas && nextBlock) {
       const context = canvas.getContext("2d");
       if (context) {
@@ -419,6 +418,13 @@ const Home: React.FC = () => {
       handsManagerRef.current.start(videoRef.current!);
     }
     const showCountdown = () => {
+      tetrisGameRef.current = null;
+      if (nextBlockRef.current !== null) {
+        const ctx = nextBlockRef.current.getContext("2d");
+        if (ctx !== null) {
+          ctx.clearRect(0, 0, 150, 150);
+        }
+      }
       return new Promise<void>(resolve => {
         let count = 3;
         const modals: HTMLElement[] = [];

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -48,6 +48,7 @@ const Home: React.FC = () => {
   const gestureRef = useRef<HTMLDivElement>(null);
   const borderRef = useRef<HTMLDivElement>(null);
   const wsManagerRef = useRef<WebSocketManager | null>(null);
+  const handsManagerRef = useRef<HandGestureManager | null>(null);
   const tetrisGameRef = useRef<TetrisGame | null>(null);
   const lastMoveTime = useRef({ right: 0, left: 0, rotate: 0, drop: 0 });
   const feedbackTimeoutRef = useRef<number | null>(null);
@@ -182,17 +183,18 @@ const Home: React.FC = () => {
     const roomCode = getRoomCode();
 
     const connectWebSocket = async () => {
-      wsManagerRef.current = new WebSocketManager();
-      try {
-        await wsManagerRef.current.connect(
-          "https://api.checkmatejungle.shop/ws",
-        );
-        subscribeToEntering(roomCode);
-      } catch (error) {
-        console.error("Failed to connect to WebSocket", error);
+      if (!wsManagerRef.current) {
+        wsManagerRef.current = new WebSocketManager();
+        try {
+          await wsManagerRef.current.connect(
+            "https://api.checkmatejungle.shop/ws",
+          );
+          subscribeToEntering(roomCode);
+        } catch (error) {
+          console.error("Failed to connect to WebSocket", error);
+        }
       }
     };
-
     connectWebSocket();
   }, []);
 
@@ -412,8 +414,10 @@ const Home: React.FC = () => {
     setShowWaitingModal(false);
     await new Promise(resolve => setTimeout(resolve, 800));
     const roomCode = getRoomCode();
-    const handsManager = new HandGestureManager(onResults);
-    handsManager.start(videoRef.current!);
+    if (!handsManagerRef.current) {
+      handsManagerRef.current = new HandGestureManager(onResults);
+      handsManagerRef.current.start(videoRef.current!);
+    }
     const showCountdown = () => {
       return new Promise<void>(resolve => {
         let count = 3;


### PR DESCRIPTION
[[🐛 FIX]](https://github.com/HandTris/FE-HandTris/commit/5eccc31ff3d59d26350da45fd2be67ed3dd1b6c5) https://github.com/HandTris/FE-HandTris/issues/166 [게임 재시작 시 WS 재연결 방지](https://github.com/HandTris/FE-HandTris/commit/5eccc31ff3d59d26350da45fd2be67ed3dd1b6c5)

### 수정 사항
- `wsMangerRef.current` 가 `null`이 아닌 경우만 WS을 구독하도록 함

[[🐛 FIX]](https://github.com/HandTris/FE-HandTris/commit/a65de4880dd39758846b3b5a24923561a993de4e) https://github.com/HandTris/FE-HandTris/issues/166 [게임 재시작 시 블럭 렌더링 영역 초기화 후 카운트다운 시작](https://github.com/HandTris/FE-HandTris/commit/a65de4880dd39758846b3b5a24923561a993de4e)

### 수정 사항
- `showCountdown` 하는 순간에 `tetrisGameRef.current` 및 `nextBlockRef` 초기화

### 참고 이미지
![블럭이_다시_그려지는_버그_수정](https://github.com/user-attachments/assets/7ce89399-9e1b-40ee-950f-2a90667a387c)

