### PR TITLE
방장 혼자 있는 방에서 로비로 접근 시 본인의 방이 보이는 버그

### DIFF
--- a/handtris/src/components/Rooms.tsx
+++ b/handtris/src/components/Rooms.tsx
@@ -31,7 +31,7 @@ function Rooms() {
   });
   useEffect(() => {
     refetch();
-  }, [refetch]);
+  }, []);
 
   const sortedRooms = useMemo(() => {
     if (!roomsData?.data) return [];

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -251,6 +251,7 @@ const Home: React.FC = () => {
                 }
               } else if (prevIsOwner === true && !parsedMessage.isOwner) {
                 setOtherUserJoined(true);
+                setIsAllReady(false);
                 fetchRoomPlayers(); // 상대방이 입장했을 때 플레이어 정보 다시 가져오기
               } else if (prevIsOwner === true && parsedMessage.isOwner) {
                 setOtherUserJoined(false);


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] 🛠️ CREATE: 새로운 파일이나 프로젝트 생성
- [ ] 🪽 FEAT: 새로운 기능 추가
- [ ] 🎨 UI/UX: 사용자 인터페이스 및 사용자 경험 개선
- [X] 🐛 FIX: 버그 수정
- [ ] 🧹 REFACTOR: 코드 리팩토링
- [ ] 🔧 CONFIG: 설정 파일 수정
- [ ] ♻️ CHORE: 기타 자잘한 작업
## 현재 상태 (AS IS)
- 게임 방을 생성한 방장이 다시 로비로 나갈 경우 자신인 만든 방이 보임
- 이를 클릭 시 들어갈 수 없는 방이라고 나옴
## 변경 사항 (TO BE)
- BackToLobby 클릭 시 WS Disconnect 되고, 서버에서 방을 지움
- 방이 지워졌으므로 로비에서 `refetch()` 시 자신의 방이 보이지 않게 됨