### PR TITLE
 [🐛 FIX] #182 서버로 부터 isOwner를 true로 받는 경우 항상 true 처리

### DIFF
--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -259,6 +259,7 @@ const Home: React.FC = () => {
               } else if (prevIsOwner === false && parsedMessage.isOwner) {
                 fetchRoomPlayers();
                 setIsOwner(true);
+                return parsedMessage.isOwner;
               }
               return prevIsOwner;
             });


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] 🛠️ CREATE: 새로운 파일이나 프로젝트 생성
- [ ] 🪽 FEAT: 새로운 기능 추가
- [ ] 🎨 UI/UX: 사용자 인터페이스 및 사용자 경험 개선
- [x] 🐛 FIX: 버그 수정
- [ ] 🧹 REFACTOR: 코드 리팩토링
- [ ] 🔧 CONFIG: 설정 파일 수정
- [ ] ♻️ CHORE: 기타 자잘한 작업
## 현재 상태 (AS IS)
- 게임 종료 후 결과 모달에서 한 플레이어가 back to lobby 버튼을 클릭 시 방에 남은 플레이어는 이를 인지하지 못 함
## 변경 사항 (TO BE)
- [ ] 서버로부터 owner 여부를 받도록 수정
- [ ] `isOwner` 가 `true`인 경우 항상 방장 상태가 되도록 수정