### PR TITLE
[🐛 FIX] #184 모달이 부모 컴포넌트에 제약 받지 않도록 함(createPortal)

### DIFF
--- a/handtris/src/components/GameResultModal.tsx
+++ b/handtris/src/components/GameResultModal.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { myStatus } from "@/services/gameService";
+import { createPortal } from "react-dom";
 import {
   Trophy,
   Frown,
@@ -78,7 +79,7 @@ const GameResultModal: React.FC<GameResultModalProps> = ({
     fetchPlayerStats();
   }, [result]);
 
-  return (
+  return createPortal(
     <motion.div
       initial={{ opacity: 0, scale: 0.8 }}
       animate={{ opacity: 1, scale: 1 }}
@@ -190,7 +191,8 @@ const GameResultModal: React.FC<GameResultModalProps> = ({
           </motion.button>
         </div>
       </div>
-    </motion.div>
+    </motion.div>,
+    document.body,
   );
 };
 


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] **🛠️ CREATE**: 새로운 파일이나 프로젝트 생성
- [ ] **🪽 FEAT**: 새로운 기능 추가
- [ ] **🎨 UI/UX**: 사용자 인터페이스 및 사용자 경험 개선
- [x] **🐛 FIX**: 버그 수정
- [ ] **🧹 REFACTOR**: 코드 리팩토링
- [ ] **📝 DOCS**: 문서 작성 및 수정
- [ ] **🔧 CONFIG**: 설정 파일 수정
- [ ] **♻️ CHORE**: 기타 자잘한 작업

## 현재 상태 (AS IS)
- 부모 컴포넌트 속의 모달이기에 부모 컴포넌트 영역 까지만 어두워짐

## 변경 사항 (TO BE)
- 모달 창을 `createPortal`을 통해 `document.body`로 보낸 후에 배경을 적용하여, 전체 화면이 어두워짐
