### PR TITLE
공격용 블럭 디자인 및 NEXT 박스 위치 수정

### DIFF
--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -39,7 +39,18 @@ const COLORS = {
     dark: "#7000CC",
     ghost: "#7000CC",
   },
-  red: { light: "#FF5B5B", main: "#FF0000", dark: "#CC0000", ghost: "#CC0000" },
+  pink: {
+    light: "#FF5BAD",
+    main: "#FF00FF",
+    dark: "#CC00CC",
+    ghost: "#CC00CC",
+  },
+  red: {
+    light: "#FF5B5B",
+    main: "#FF0000",
+    dark: "#CC0000",
+    ghost: "#CC0000",
+  },
 };
 
 export class TetrisGame {

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -131,6 +131,14 @@ const Home: React.FC = () => {
                   nextBlock.color,
                   false,
                 );
+              } else if (nextBlock.color === "pink") {
+                tetrisGameRef.current.drawSquareCanvas(
+                  context,
+                  x + 1.05,
+                  y + 0.45,
+                  nextBlock.color,
+                  false,
+                );
               } else {
                 //"cyan"
                 tetrisGameRef.current.drawSquareCanvas(


### PR DESCRIPTION
> Closes #188 

## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] **🛠️ CREATE**: 새로운 파일이나 프로젝트 생성
- [ ] **🪽 FEAT**: 새로운 기능 추가
- [x] **🎨 UI/UX**: 사용자 인터페이스 및 사용자 경험 개선
- [ ] **🐛 FIX**: 버그 수정
- [ ] **🧹 REFACTOR**: 코드 리팩토링
- [ ] **📝 DOCS**: 문서 작성 및 수정
- [ ] **🔧 CONFIG**: 설정 파일 수정
- [ ] **♻️ CHORE**: 기타 자잘한 작업

## 현재 상태 (AS IS)
- "pink" color 단색으로 ghost, shadow 등이 표시되는 중
- NEXT 표시 블럭에서 Default 위치로 반영되어 플레이어가 봤을 때 박스의 중앙에 위치하고 있지 않음

## 변경 사항 (TO BE)
- 다른 color들과 동일하게 ghost, shadow 등이 구분되도록 색상을 표시함
- NEXT 표시 블럭에 공격용 블럭이 중앙에 위치하도록 미세 조정

### 참고

![image](https://github.com/user-attachments/assets/e4a8bf60-9975-4366-ad8b-038cf20cdcca)
- 공격 블럭 디자인

![image](https://github.com/user-attachments/assets/eec64024-39a1-4506-b3ed-6cdd6a8c9a57)
- NEXT 표시 칸의 블럭 위치 