### PR TITLE
[🐛 FIX] 쿠키의 accessToken 여부에 따라 로그인 라우트로 이동하지 않는 버그 수정

### DIFF
--- a/handtris/src/app/login/page.tsx
+++ b/handtris/src/app/login/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React from "react";
-import LoginForm from "../../components/LoginForm";
+const LoginForm = dynamic(() => import("../../components/LoginForm"));
+import dynamic from "next/dynamic";
 
 const LoginPage = () => {
   return (

--- a/handtris/src/components/LoginForm.tsx
+++ b/handtris/src/components/LoginForm.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import { motion } from "framer-motion";
 import { Formik, Form, FormikHelpers } from "formik";
@@ -36,7 +37,6 @@ const LoginForm = () => {
           values,
           { setSubmitting, setFieldError }: FormikHelpers<LoginFormValues>,
         ) => {
-          // 기존 토큰 삭제
           Cookies.remove("accessToken", { path: "/" });
           Cookies.remove("refreshToken", { path: "/" });
 
@@ -50,13 +50,11 @@ const LoginForm = () => {
               Cookies.set("accessToken", accessToken, {
                 path: "/",
                 sameSite: "lax",
-                secure: process.env.NODE_ENV === "production",
                 expires: 1,
               });
               Cookies.set("refreshToken", refreshToken, {
                 path: "/",
                 sameSite: "lax",
-                secure: process.env.NODE_ENV === "production",
                 expires: 1,
               });
 
@@ -71,6 +69,7 @@ const LoginForm = () => {
               if (setAccessToken && setRefreshToken) {
                 setSubmitting(false);
                 router.push("/lobby");
+                router.refresh();
                 setTimeout(() => showLoginSuccessToast(toast), 100);
               } else {
                 console.error("Failed to set tokens");


### PR DESCRIPTION
## 관련 이슈 번호
Closes #200 

## 변경 사항 (TO BE)
- `router.push('/lobby')`에 추가로 `router.refresh()` 코드 추가
- 라우터가 새로운 상태를 반영하고, 정상적 라우트 이동 구현

## 참여자
@bishoe01 