### PR TITLE
블록 Hard Drop 시 Canvas 아래 방향 상하로 떨리도록 수정 및 버그 fix

### DIFF
--- a/handtris/src/app/globals.css
+++ b/handtris/src/app/globals.css
@@ -229,27 +229,27 @@ canvas {
 
 @keyframes shake {
     0% {
-        transform: translateY(-50px) scale(1.05);
+      transform: translateY(50px);
     }
     10% {
-        transform: translateY(0) scale(1);
+      transform: translateY(0);
     }
     30% {
-        transform: translateY(-35px) scale(1.03);
+      transform: translateY(35px);
     }
     50% {
-        transform: translateY(0) scale(0.97);
+      transform: translateY(0);
     }
     70% {
-        transform: translateY(-15px) scale(1.02);
+      transform: translateY(15px);
     }
     85% {
-        transform: translateY(0) scale(0.99);
+      transform: translateY(0);
     }
     100% {
-        transform: translateY(0) scale(1);
+      transform: translateY(0);
     }
-}
+  }
 
 .shake {
     animation: shake 0.2s;

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -565,7 +565,6 @@ const Home: React.FC = () => {
                   //     }, 500);
                   //   }, 3000);
                   // }
-
                 }
                 if (message.isGaugeFull) {
                   tetrisGameRef.current.isGaugeFullAttacked = true;
@@ -1011,6 +1010,9 @@ const Home: React.FC = () => {
                           height={"-30px"}
                         />
                       </div>
+                    </div>
+                  </div>
+                )}
                 {!isHandDetected && (
                   <div className="absolute inset-0 z-30 bg-black bg-opacity-70 flex items-center justify-center">
                     <div className="text-yellow-400 text-4xl font-bold pixel animate-pulse text-center">
@@ -1103,15 +1105,6 @@ const Home: React.FC = () => {
                     alt="profile"
                     className="h-full w-full overflow-hidden object-cover"
                   />
-                  <div className="absolute inset-0">
-                    <canvas
-                      ref={confettiRef}
-                      id="canvas"
-                      width="350"
-                      height="271"
-                      className=""
-                    />
-                  </div>
                 </div>
               </div>
             </div>

--- a/handtris/src/components/WebSocketManager.ts
+++ b/handtris/src/components/WebSocketManager.ts
@@ -120,6 +120,9 @@ export class WebSocketManager {
           //   }, 3000);
           // }
         }
+        if (message.isGaugeFull) {
+          isGaugeFull = false;
+        }
       } else {
         console.log("WebSocket connection is not established yet.");
       }


### PR DESCRIPTION
## 관련 이슈 번호
> #47 
## 현재 상황 (AS IS)
- 블럭 Hard Drop 시 Canvas가 위 방향으로 상하로 떨리는 중임
- HOME JSX Div pair가 맞지 않음
## 변경 사항 (TO BE)
- Hard Drop 시 Canvas 상하로 떨리도록 수정
- Home JSX Div pair 맞춰줌
- 도넛 블럭 공격이 여러 번 되는 것을 방지하는 조건문 추가

## 참여자
@otfeb @forrest1398 @seungineer 