### PR TITLE
[🐛FIX] 한 번의 도넛 블럭 공격 시 여러 개의 도넛 블럭이 나오는 버그 수정

### DIFF
--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -563,7 +563,7 @@ export class Piece {
     playSoundEffect("/sound/placed.ogg");
     this.game.drawBoard();
     this.game.wsManager.sendMessageOnGaming(
-      this,
+      this.game,
       this.game.board_forsend,
       this.game.isEnd,
       this.game.isRowFull,

--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -249,6 +249,7 @@ export class TetrisGame {
       this.dropStart = Date.now();
       if (!this.gameEnd) {
         this.wsManager.sendMessageOnGaming(
+          this,
           this.board_forsend,
           this.isEnd,
           this.isAttack,
@@ -562,6 +563,7 @@ export class Piece {
     playSoundEffect("/sound/placed.ogg");
     this.game.drawBoard();
     this.game.wsManager.sendMessageOnGaming(
+      this,
       this.game.board_forsend,
       this.game.isEnd,
       this.game.isRowFull,

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -345,7 +345,7 @@ const Home: React.FC = () => {
             );
           }
         }
-      }, 70000);
+      }, 7000000); //NOTE - 자동 대기 방으로 이동하지 않도록 큰 수를 넣음
 
       return () => clearTimeout(timeoutId);
     }
@@ -617,6 +617,7 @@ const Home: React.FC = () => {
           }, 1000);
         }
         drawNextBlock(tetrisGameRef.current.getNextBlock());
+        tetrisGameRef.current.isGaugeFull = false;
       }
     }, 1000);
     return () => clearInterval(interval);

--- a/handtris/src/components/WebSocketManager.ts
+++ b/handtris/src/components/WebSocketManager.ts
@@ -3,6 +3,7 @@ import { getAccessToken } from "@/util/getAccessToken";
 import { getRoomCode } from "@/util/getRoomCode";
 import SockJS from "sockjs-client";
 import Stomp, { Client, Frame, Message } from "stompjs";
+import { TetrisGame } from "./TetrisGame";
 
 interface WaitingInfo {
   isAllReady: boolean;
@@ -91,7 +92,7 @@ export class WebSocketManager {
   }
 
   sendMessageOnGaming(
-    game: any,
+    game: TetrisGame,
     board: TetrisBoard,
     isEnd: boolean,
     isAttack: boolean,

--- a/handtris/src/components/WebSocketManager.ts
+++ b/handtris/src/components/WebSocketManager.ts
@@ -91,6 +91,7 @@ export class WebSocketManager {
   }
 
   sendMessageOnGaming(
+    game: any,
     board: TetrisBoard,
     isEnd: boolean,
     isAttack: boolean,
@@ -121,7 +122,7 @@ export class WebSocketManager {
           // }
         }
         if (message.isGaugeFull) {
-          isGaugeFull = false;
+          game.isGaugeFull = false;
         }
       } else {
         console.log("WebSocket connection is not established yet.");

--- a/handtris/src/types/index.ts
+++ b/handtris/src/types/index.ts
@@ -1,3 +1,5 @@
+import { Piece } from "@/components/TetrisGame";
+import { WebSocketManager } from "@/components/WebSocketManager";
 import { LandmarkList } from "@mediapipe/hands";
 
 export type TetrisBoard = string[][];
@@ -29,3 +31,68 @@ export type UserInfo = {
   winRate: number;
   profileImageUrl: string;
 };
+
+export interface TetrisGame {
+  isDangerous: boolean;
+  ROW: number;
+  COL: number;
+  SQ: number;
+  VACANT: string;
+  GRID_COLOR: string;
+  board: string[][];
+  board_forsend: string[][];
+  ctx: CanvasRenderingContext2D;
+  ctx2: CanvasRenderingContext2D;
+  p: Piece;
+  dropStart: number;
+  gameOver: boolean;
+  gameEnd: boolean;
+  isEnd: boolean;
+  hasSentEndMessage: boolean;
+  wsManager: WebSocketManager;
+  setGameResult: (result: string) => void;
+  flashRow: (row: number) => void;
+  clearRow: (row: number) => void;
+  linesCleared: number;
+  roomCode: string | null;
+  isGameStart: boolean;
+  isRowFull: boolean;
+  isAttack: boolean;
+  isAttacked: boolean;
+  nextBlock: Piece;
+  isGaugeFull: boolean;
+  isGaugeFullAttacked: boolean;
+  pieceBag: Piece[];
+  toggleAttackEffect: boolean;
+  toggleAttackedEffect: boolean;
+  previousGreyRows: Set<number>;
+  drawSquareCanvas: (
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    color: string,
+    isGhost: boolean,
+  ) => void;
+  drawSquare: (
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    color: string,
+    isGhost: boolean,
+  ) => void;
+  createBoard: () => string[][];
+  checkDangerousState: () => void;
+  drawBoard: () => void;
+  drawBoard2: (board2: string[][]) => void;
+  createNewBag: () => Piece[];
+  getNextPieceFromBag: () => Piece;
+  randomPiece: () => Piece;
+  gaugeFullPiece: () => Piece;
+  getNextBlock: () => Piece;
+  drop: () => void;
+  showGameResult: (result: string) => void;
+  flashRowEffect: (row: number) => void;
+  moveToGhostPosition: () => void;
+  calculateGhostPosition: () => { x: number; y: number };
+  addBlockRow: () => void;
+}


### PR DESCRIPTION
## 관련 이슈 번호
> #205 

## 현재 상태 (AS IS)
- 도넛 공격을 한 번만 실행했을 때도 STOMP Message로 여러 번의 도넛 공격이 상대에게 전달됨
- `isGaugeFull`이 `true` 인 log가 여러 번 출력됨

## 변경 사항 (TO BE)
- `sendMessageOnGaming` 함수 인자에 `this.game`을 추가하여 `game`의 `isGaugeFull`을 직접적으로 수정함
## 참고
![image](https://github.com/user-attachments/assets/4ab289ed-8b66-4502-b379-2bfd5b4e3052)
- 공격 받은 플레이어의 console에 `isGaugeFull: true`가 단 한 개만 출력됨
## 참여자
@seungineer