### PR TITLE
게이지 수준에 따른 공격 Type 매핑 기능 구현

### DIFF
--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -261,6 +261,7 @@ export class TetrisGame {
     this.checkDangerousState();
     if (this.isAttack) {
       this.toggleAttackEffect = true;
+      this.isAttack = false;
     }
 
     if (!this.gameEnd && !this.gameOver) {
@@ -566,7 +567,7 @@ export class Piece {
       this.game,
       this.game.board_forsend,
       this.game.isEnd,
-      this.game.isRowFull,
+      this.game.isAttack,
       this.game.roomCode,
       this.game.isGaugeFull,
     );
@@ -578,6 +579,7 @@ export class Piece {
     }
     if (this.game.isAttack) {
       this.game.toggleAttackEffect = true;
+      this.game.isAttack = false;
     }
   }
 

--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -28,11 +28,12 @@ export class TetrisGame {
   roomCode: string | null;
   isGameStart: boolean;
   isRowFull: boolean;
-  isAttack: boolean;
-  isAttacked: boolean;
+  isAddAttack: boolean;
+  isAddAttacked: boolean;
+  isFlipAttack: boolean;
+  isDonutAttack: boolean;
+  isDonutAttacked: boolean;
   nextBlock: Piece;
-  isGaugeFull: boolean;
-  isGaugeFullAttacked: boolean;
   pieceBag: Piece[];
   toggleAttackEffect: boolean;
   toggleAttackedEffect: boolean;
@@ -73,12 +74,14 @@ export class TetrisGame {
     this.clearRow = this.clearFullRow;
     this.linesCleared = 0;
     this.isRowFull = false;
-    this.isAttack = false;
+    this.isAddAttack = false;
+    this.isFlipAttack = false;
+    this.isDonutAttack = false;
     this.toggleAttackEffect = false;
     this.toggleAttackedEffect = false;
-    this.isAttacked = false;
-    this.isGaugeFull = false;
-    this.isGaugeFullAttacked = false;
+    this.isAddAttacked = false;
+    this.isDonutAttack = false;
+    this.isDonutAttacked = false;
     this.previousGreyRows = new Set();
 
     this.drawBoard();
@@ -250,19 +253,19 @@ export class TetrisGame {
       if (!this.gameEnd) {
         this.wsManager.sendMessageOnGaming(
           this,
+          this.roomCode,
           this.board_forsend,
           this.isEnd,
-          this.isAttack,
-          this.roomCode,
-          this.isGaugeFull,
+          this.isAddAttack,
+          this.isFlipAttack,
+          this.isDonutAttack,
         );
+        this.isAddAttack = false;
+        this.isFlipAttack = false;
+        this.isDonutAttack = false;
       }
     }
     this.checkDangerousState();
-    if (this.isAttack) {
-      this.toggleAttackEffect = true;
-      this.isAttack = false;
-    }
 
     if (!this.gameEnd && !this.gameOver) {
       requestAnimationFrame(this.drop.bind(this));
@@ -456,9 +459,9 @@ export class Piece {
     } else {
       this.lock();
       this.game.p = this.game.nextBlock;
-      if (this.game.isGaugeFullAttacked == true) {
+      if (this.game.isDonutAttacked == true) {
         this.game.nextBlock = this.game.gaugeFullPiece();
-        this.game.isGaugeFullAttacked = false;
+        this.game.isDonutAttacked = false;
       } else {
         this.game.nextBlock = this.game.randomPiece();
       }
@@ -563,23 +566,24 @@ export class Piece {
     }
     playSoundEffect("/sound/placed.ogg");
     this.game.drawBoard();
+    if (this.game.isAddAttacked) {
+      this.game.addBlockRow();
+      this.game.isAddAttacked = false;
+    }
     this.game.wsManager.sendMessageOnGaming(
       this.game,
+      this.game.roomCode,
       this.game.board_forsend,
       this.game.isEnd,
-      this.game.isAttack,
-      this.game.roomCode,
-      this.game.isGaugeFull,
+      this.game.isAddAttack,
+      this.game.isFlipAttack,
+      this.game.isDonutAttack,
     );
     this.game.isRowFull = false;
-    this.game.isGaugeFull = false;
-    if (this.game.isAttacked) {
-      this.game.addBlockRow();
-      this.game.isAttacked = false;
-    }
-    if (this.game.isAttack) {
-      this.game.toggleAttackEffect = true;
-      this.game.isAttack = false;
+    this.game.isDonutAttack = false;
+    if (this.game.isAddAttack) {
+      // this.game.toggleAttackEffect = true;
+      this.game.isAddAttack = false;
     }
   }
 

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -537,8 +537,9 @@ const Home: React.FC = () => {
             (message: {
               board: TetrisBoard;
               isEnd: boolean;
-              isAttack: boolean;
-              isGaugeFull: boolean;
+              isAddAttack: boolean;
+              isFlipAttack: boolean;
+              isDonutAttack: boolean;
             }) => {
               if (tetrisGameRef.current) {
                 if (message.isEnd) {
@@ -547,28 +548,30 @@ const Home: React.FC = () => {
                   playSoundEffect("/sound/winner.mp3");
                   setGameResult("you WIN!");
                 }
-                if (message.isAttack) {
+                if (message.isAddAttack) {
                   // tetrisGameRef.current.addBlockRow(); //NOTE - 실시간 공격 적용 시 이 부분 수정 필요
-                  tetrisGameRef.current.isAttacked = true;
-
+                  tetrisGameRef.current.isAddAttacked = true;
+                } else if (message.isFlipAttack) {
                   // tetrisGameRef.current.toggleAttackedEffect = true;
-                  // const playOppTetrisElement =
-                  //   document.getElementById("tetris-container");
-                  // if (playOppTetrisElement) {
-                  //   playOppTetrisElement.classList.add("flipped-canvas");
-                  //   setTimeout(() => {
-                  //     playOppTetrisElement.classList.add("unflipped-canvas");
-                  //     setTimeout(() => {
-                  //       playOppTetrisElement.classList.remove("flipped-canvas");
-                  //       playOppTetrisElement.classList.remove(
-                  //         "unflipped-canvas",
-                  //       );
-                  //     }, 500);
-                  //   }, 3000);
-                  // }
-                }
-                if (message.isGaugeFull) {
-                  tetrisGameRef.current.isGaugeFullAttacked = true;
+                  const playOppTetrisElement =
+                    document.getElementById("tetris-container");
+                  if (
+                    playOppTetrisElement &&
+                    !playOppTetrisElement.classList.contains("flipped-canvas")
+                  ) {
+                    playOppTetrisElement.classList.add("flipped-canvas");
+                    setTimeout(() => {
+                      playOppTetrisElement.classList.add("unflipped-canvas");
+                      setTimeout(() => {
+                        playOppTetrisElement.classList.remove("flipped-canvas");
+                        playOppTetrisElement.classList.remove(
+                          "unflipped-canvas",
+                        );
+                      }, 500);
+                    }, 3000);
+                  }
+                } else if (message.isDonutAttack) {
+                  tetrisGameRef.current.isDonutAttacked = true;
                 }
                 tetrisGameRef.current.drawBoard2(message.board);
               }
@@ -606,12 +609,14 @@ const Home: React.FC = () => {
           newGauge = 3;
         }
         setGauge(newGauge);
+        console.log("newGauge: ", newGauge);
         if (newGauge == 1 && tetrisGameRef.current) {
-          tetrisGameRef.current.isAttack = true;
+          tetrisGameRef.current.isAddAttack = true;
+          console.log("이즈애드어택", tetrisGameRef.current.isAddAttack);
         } else if (newGauge == 2 && tetrisGameRef.current) {
-          tetrisGameRef.current.isGaugeFull = true;
-        } else {
-          tetrisGameRef.current.isGaugeFull = true;
+          tetrisGameRef.current.isFlipAttack = true;
+        } else if (newGauge == 3 && tetrisGameRef.current) {
+          tetrisGameRef.current.isDonutAttack = true;
         }
 
         if (newGauge === 3 && tetrisGameRef.current.linesCleared > 0) {
@@ -620,8 +625,8 @@ const Home: React.FC = () => {
           }, 1000);
         }
 
-        if (!tetrisGameRef.current.isGaugeFull && newGauge === 3) {
-          tetrisGameRef.current.isGaugeFull = true;
+        if (!tetrisGameRef.current.isDonutAttack && newGauge === 3) {
+          tetrisGameRef.current.isDonutAttack = true;
         }
       }
       previousLinesClearedRef.current = currentLinesCleared;
@@ -633,7 +638,7 @@ const Home: React.FC = () => {
       if (tetrisGameRef.current) {
         setLinesCleared(tetrisGameRef.current.linesCleared);
         drawNextBlock(tetrisGameRef.current.getNextBlock());
-        tetrisGameRef.current.isGaugeFull = false;
+        tetrisGameRef.current.isDonutAttack = false;
       }
     }, 1000);
     return () => clearInterval(interval);

--- a/handtris/src/components/TetrisPlay.tsx
+++ b/handtris/src/components/TetrisPlay.tsx
@@ -606,6 +606,13 @@ const Home: React.FC = () => {
           newGauge = 3;
         }
         setGauge(newGauge);
+        if (newGauge == 1 && tetrisGameRef.current) {
+          tetrisGameRef.current.isAttack = true;
+        } else if (newGauge == 2 && tetrisGameRef.current) {
+          tetrisGameRef.current.isGaugeFull = true;
+        } else {
+          tetrisGameRef.current.isGaugeFull = true;
+        }
 
         if (newGauge === 3 && tetrisGameRef.current.linesCleared > 0) {
           setTimeout(() => {

--- a/handtris/src/components/WebSocketManager.ts
+++ b/handtris/src/components/WebSocketManager.ts
@@ -93,14 +93,21 @@ export class WebSocketManager {
 
   sendMessageOnGaming(
     game: TetrisGame,
+    roomCode: string | null,
     board: TetrisBoard,
     isEnd: boolean,
-    isAttack: boolean,
-    roomCode: string | null,
-    isGaugeFull: boolean,
+    isAddAttack: boolean,
+    isFlipAttack: boolean,
+    isDonutAttack: boolean,
   ) {
     if (this.stompClient && this.stompClient.connected) {
-      const message = { board, isEnd, isAttack, isGaugeFull };
+      const message = {
+        board,
+        isEnd,
+        isAddAttack,
+        isFlipAttack,
+        isDonutAttack,
+      };
       if (this.connected) {
         this.stompClient.send(
           `/app/${roomCode}/tetris`,
@@ -108,22 +115,22 @@ export class WebSocketManager {
           JSON.stringify(message),
         );
         console.log("Message sent: ", message);
-        if (message.isAttack) {
-          // const playOppTetrisElement =
-          //   document.getElementById("opposer_tetris");
-          // if (playOppTetrisElement) {
-          //   playOppTetrisElement.classList.add("flipped-canvas");
-          //   setTimeout(() => {
-          //     playOppTetrisElement.classList.add("unflipped-canvas");
-          //     setTimeout(() => {
-          //       playOppTetrisElement.classList.remove("flipped-canvas");
-          //       playOppTetrisElement.classList.remove("unflipped-canvas");
-          //     }, 500);
-          //   }, 3000);
-          // }
+        if (message.isFlipAttack) {
+          const playOppTetrisElement =
+            document.getElementById("opposer_tetris");
+          if (playOppTetrisElement) {
+            playOppTetrisElement.classList.add("flipped-canvas");
+            setTimeout(() => {
+              playOppTetrisElement.classList.add("unflipped-canvas");
+              setTimeout(() => {
+                playOppTetrisElement.classList.remove("flipped-canvas");
+                playOppTetrisElement.classList.remove("unflipped-canvas");
+              }, 500);
+            }, 3000);
+          }
         }
-        if (message.isGaugeFull) {
-          game.isGaugeFull = false;
+        if (message.isDonutAttack) {
+          game.isDonutAttack = false;
         }
       } else {
         console.log("WebSocket connection is not established yet.");

--- a/handtris/src/types/index.ts
+++ b/handtris/src/types/index.ts
@@ -6,7 +6,7 @@ export type TetrisBoard = string[][];
 export type TetrisMessage = {
   board: TetrisBoard;
   isEnd: boolean;
-  isAttack: boolean;
+  isAddAttack: boolean;
 };
 
 export interface HandLandmarkResults {
@@ -57,11 +57,12 @@ export interface TetrisGame {
   roomCode: string | null;
   isGameStart: boolean;
   isRowFull: boolean;
-  isAttack: boolean;
-  isAttacked: boolean;
+  isAddAttack: boolean;
+  isAddAttacked: boolean;
   nextBlock: Piece;
-  isGaugeFull: boolean;
-  isGaugeFullAttacked: boolean;
+  isFlipAttack: boolean;
+  isDonutAttack: boolean;
+  isDonutAttacked: boolean;
   pieceBag: Piece[];
   toggleAttackEffect: boolean;
   toggleAttackedEffect: boolean;


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [ ] **🛠️ CREATE**: 새로운 파일이나 프로젝트 생성
- [x] **🪽 FEAT**: 새로운 기능 추가
- [ ] **🎨 UI/UX**: 사용자 인터페이스 및 사용자 경험 개선
- [x] **🐛 FIX**: 버그 수정
- [ ] **🧹 REFACTOR**: 코드 리팩토링
- [ ] **📝 DOCS**: 문서 작성 및 수정
- [ ] **🔧 CONFIG**: 설정 파일 수정
- [ ] **♻️ CHORE**: 기타 자잘한 작업

## 현재 상태 (AS IS)
- 한 줄을 완성할 때마다 상대 테트리스 Board 아래에 공격 블럭("grey")이 추가됨
- 한 줄을 완성할 때마다 공격 블럭 추가와 더불어 테트리스 화면이 flip됨
- 게이지를 모두 채울 경우(`isGaugeFull = true`) 상대 테트리스 Board에 도넛 블럭 공격을 함
- Max gauge를 뛰어 넘을 수 있음(예: 게이지가 2일 때, 두 줄을 연속으로 완성한 경우 3을 뛰어넘고, 1이 됨)
## 변경 사항 (TO BE)
- [x] 게이지가 한 칸인 경우 상대 테트리스 Board 아래에 공격 블럭("grey")이 추가됨
- `isAddAttack = true`일 때, 아래에 공격 블럭이 추가됨
- [x] 게이지가 두 칸인 경우 상대 테트리스 화면을 flip시킴
- `isFlipAttack = true`일 때, 상대 테트리스 화면을 flip
- 공격 플레이어도 flip되고 있는 상대 테트리스 화면을 볼 수 있음
- [x] 게이지가 세 칸인 경우 상대 테트리스 Board에 도넛 블럭 공격을 함
- `isDonutAttack`일 때, 도넛 블럭 공격이 가해짐
- [x] Max gauge를 뛰어 넘는 경우 항상 게이지는 3이 되었다가 다시 0이 되도록 함
- `newGauge`를 갱신해가며, `newGauge` 가 4 이상인 경우 3으로 할당함(1000ms 이후 0으로 초기화)