### PR TITLE
[🐛FIX] 게임이 두 번 실행되는 버그 수정

### DIFF
--- a/handtris/src/components/WaitingModal.tsx
+++ b/handtris/src/components/WaitingModal.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useState } from "react";
 import { createPortal } from "react-dom";
 import { UserCard } from "./UserCard";
 import { motion, AnimatePresence } from "framer-motion";
@@ -41,6 +42,7 @@ const WaitingModal = ({
   wsManager,
 }: WaitingModalProps) => {
   const router = useRouter();
+  const [isButtonClicked, setIsButtonClicked] = useState(false);
 
   if (!isOpen) return null;
 
@@ -53,7 +55,17 @@ const WaitingModal = ({
     return isReady ? "Cancel Ready" : "Ready";
   };
 
-  const isButtonDisabled = players.length < 2;
+  const isButtonDisabled =
+    players.length < 2 || (isButtonClicked && getButtonText() === "Start Game");
+
+  const handleButtonClick = () => {
+    if (getButtonText() === "Start Game") {
+      setIsButtonClicked(true);
+      onStartGame();
+    } else {
+      onReadyToggle();
+    }
+  };
 
   const handleBackToLobby = () => {
     const roomCode = sessionStorage.getItem("roomCode");
@@ -137,7 +149,7 @@ const WaitingModal = ({
             </div>
           </div>
           <button
-            onClick={isOwner ? onStartGame : onReadyToggle}
+            onClick={handleButtonClick}
             className={`mt-4 text-3xl pixel px-6 py-4 text-white rounded-lg transition-colors ${
               isButtonDisabled
                 ? "bg-gray-500 cursor-not-allowed"

--- a/handtris/src/components/WaitingModal.tsx
+++ b/handtris/src/components/WaitingModal.tsx
@@ -56,10 +56,10 @@ const WaitingModal = ({
   };
 
   const isButtonDisabled =
-    players.length < 2 || (isButtonClicked && getButtonText() === "Start Game");
+    players.length < 2 || (isButtonClicked && getButtonText() === "Game Start");
 
   const handleButtonClick = () => {
-    if (getButtonText() === "Start Game") {
+    if (getButtonText() === "Game Start") {
       setIsButtonClicked(true);
       onStartGame();
     } else {


### PR DESCRIPTION
## 관련 이슈 번호
> Close #215 

## 현재 상태 (AS IS)
- 간헐적으로 게임이 두 번 실행되는 버그가 있음

## 변경 사항 (TO BE)
- `"Game Start"` 버튼을 클릭했을 때 곧바로 disabled 상태로 전환하여 두 번 클릭되는 것을 방지함

### 참고
![네 번 실행 버그 로그](https://github.com/user-attachments/assets/b1f5ce9e-f39f-4269-a831-ed2b1fac71f0)
- 한 번의 게임 실행에 세 번의 `"isStart" : true` 로그가 찍혀야 하나 여섯 번의 로그가 찍힘
- 버튼이 두 번 클릭되어 STOMP Message를 중복하여 보내고, 게임 실행 명령을 중복하여 받아 버그가 발생함