### PR TITLE
[🐛 FIX] #225 도넛블럭이 연속해서 두 번 나올 수 없도록 조건 추가

### DIFF
--- a/handtris/src/components/TetrisGame.ts
+++ b/handtris/src/components/TetrisGame.ts
@@ -95,6 +95,7 @@ export class TetrisGame {
   }
 
   clearFullRow(row: number) {
+    this.linesCleared++;
     for (let y = row; y > 1; y--) {
       for (let c = 0; c < this.COL; c++) {
         this.board[y][c] = this.board[y - 1][c];
@@ -104,7 +105,6 @@ export class TetrisGame {
       this.board[0][c] = this.VACANT;
     }
     this.drawBoard();
-    this.linesCleared++;
   }
 
   createBoard(): string[][] {
@@ -518,7 +518,7 @@ export class Piece {
     } else {
       this.lock();
       this.game.p = this.game.nextBlock;
-      if (this.game.isDonutAttacked == true) {
+      if (this.game.isDonutAttacked == true && this.game.p.color !== "pink") {
         this.game.nextBlock = this.game.gaugeFullPiece();
         this.game.isDonutAttacked = false;
       } else {
@@ -614,13 +614,13 @@ export class Piece {
       }
       if (isRowFull) {
         this.game.isRowFull = true;
+        this.game.clearRow(r);
         for (let y = r; y > 1; y--) {
           for (let c = 0; c < this.game.COL; c++) {
             this.game.board_forsend[y][c] = this.game.board_forsend[y - 1][c];
           }
         }
         // this.game.flashRow(r);
-        this.game.clearRow(r);
         const playTetrisElement = document.getElementById("tetris-container");
         if (playTetrisElement) {
           playTetrisElement.classList.add("shakeRow");


### PR DESCRIPTION
## 관련 이슈 번호
> Closes #225 

## 변경 사항 (TO BE)
- `movedown()`과 `moveToGhostPosition()` 함수의 순서가 우연찮게 겹치는 경우 방지
- `this.game.p.color` 가 `"pink"`가 아닐 때만 도넛 블럭을 `nextBlock`에 할당할 수 있게 함 

참여자
@seungineer 